### PR TITLE
update relayer basic url

### DIFF
--- a/src/routes/pages/en/relay-implementations.md
+++ b/src/routes/pages/en/relay-implementations.md
@@ -5,7 +5,7 @@ description: This is a list of all known implementations of the Nostr relay spec
 
 ## Go
 
--   [Relayer Basic](https://github.com/fiatjaf/relayer/tree/master/basic): A simple reference relay backed by Postgres, written as a demo on top of the [Relayer](https://github.com/fiatjaf/relayer) framework for building custom relays
+-   [Relayer Basic](https://github.com/fiatjaf/relayer/tree/master/examples/basic): A simple reference relay backed by Postgres, written as a demo on top of the [Relayer](https://github.com/fiatjaf/relayer) framework for building custom relays
 
 ## C++
 

--- a/src/routes/pages/es/relay-implementations.md
+++ b/src/routes/pages/es/relay-implementations.md
@@ -5,7 +5,7 @@ description: Esta es una lista de todas las implementaciones conocidas de la esp
 
 ## Go
 
--   [Relayer Basic](https://github.com/fiatjaf/relayer/tree/master/basic): Un sencillo relé de referencia respaldado por Postgres, escrito como una demostración sobre el marco de trabajo [Relayer](https://github.com/fiatjaf/relayer) para construir relés personalizados.
+-   [Relayer Basic](https://github.com/fiatjaf/relayer/tree/master/examples/basic): Un sencillo relé de referencia respaldado por Postgres, escrito como una demostración sobre el marco de trabajo [Relayer](https://github.com/fiatjaf/relayer) para construir relés personalizados.
 
 ## C++
 

--- a/src/routes/pages/fa/relay-implementations.md
+++ b/src/routes/pages/fa/relay-implementations.md
@@ -5,7 +5,7 @@ description: این لیستی از مشخصات تمام رله های شناخ
     
 ## Go
  
--   [Relayer Basic](https://github.com/fiatjaf/relayer/tree/master/basic): یک رله مرجع ساده است که با Postgres پشتیبانی می شود؛ به عنوان نمونه نمایشی روی چارچوب[Relayer](https://github.com/fiatjaf/relayer) برای ساخت رله های سفارشی نوشته شده شده 
+-   [Relayer Basic](https://github.com/fiatjaf/relayer/tree/master/examples/basic): یک رله مرجع ساده است که با Postgres پشتیبانی می شود؛ به عنوان نمونه نمایشی روی چارچوب[Relayer](https://github.com/fiatjaf/relayer) برای ساخت رله های سفارشی نوشته شده شده 
 
 
 

--- a/src/routes/pages/fr/relay-implementations.md
+++ b/src/routes/pages/fr/relay-implementations.md
@@ -5,7 +5,7 @@ description: Ceci est une liste de toutes les implémentations connues de la sp�
 
 ## Go
 
-- [Relayer Basic](https://github.com/fiatjaf/relayer/tree/master/basic) : Un relais de référence simple qui utilise Postgres comme base de données, écrit comme une démo au dessus du framework [Relayer](https://github.com/fiatjaf/relayer) pour construire des relais personnalisés.
+- [Relayer Basic](https://github.com/fiatjaf/relayer/tree/master/examples/basic) : Un relais de référence simple qui utilise Postgres comme base de données, écrit comme une démo au dessus du framework [Relayer](https://github.com/fiatjaf/relayer) pour construire des relais personnalisés.
 
 ## C++
 

--- a/src/routes/pages/it/relay-implementations.md
+++ b/src/routes/pages/it/relay-implementations.md
@@ -5,7 +5,7 @@ description: Questo è un elenco di tutte le implementazioni note della specific
 
 ## Go
 
--   [Relayer Basic](https://github.com/fiatjaf/relayer/tree/master/basic): A simple reference relay backed by Postgres, written as a demo on top of the [Relayer](https://github.com/fiatjaf/relayer) framework for building custom relays
+-   [Relayer Basic](https://github.com/fiatjaf/relayer/tree/master/examples/basic): A simple reference relay backed by Postgres, written as a demo on top of the [Relayer](https://github.com/fiatjaf/relayer) framework for building custom relays
 
 ## C++
 


### PR DESCRIPTION
Looks like relayer moved the basic implementation into a subdirectory https://github.com/fiatjaf/relayer/commit/47b8ee106f68f799c6a07db04d9d5502b914e01b