### PR TITLE
fix typo `wallet of statoshi` to `wallet of satoshi`

### DIFF
--- a/src/routes/pages/de/zaps.md
+++ b/src/routes/pages/de/zaps.md
@@ -46,4 +46,4 @@ Stelle dir folgende Beispiele vor:
 
 1. Du hast eine [Stacker News](https://stacker.news/) Lightning-Adresse in deinem Nostr-Profil eingetragen, hier erhältst du alle gezappten Sats.
 1. In deinem Webbrowser verwendest du Iris als Client und sendest Zaps mit deiner Alby-Wallet über die Browser-Erweiterung.
-1. Auf dem Smartphone verwendest du Damus als Client und sendest Zaps mit der Wallet of Statoshi-App.
+1. Auf dem Smartphone verwendest du Damus als Client und sendest Zaps mit der Wallet of Satoshi-App.

--- a/src/routes/pages/en/zaps.md
+++ b/src/routes/pages/en/zaps.md
@@ -46,4 +46,4 @@ For example, imagine the following:
 
 1. You have a [Stacker News](https://stacker.news/) lightning address set in your Nostr profile, this is where you'll receive any zapped sats.
 2. In your web browser, you use Iris as your client and pay for Zaps using your Alby wallet via their chrome extension
-3. On mobile, you use Damus as your client and pay for Zaps using the Wallet of Statoshi app.
+3. On mobile, you use Damus as your client and pay for Zaps using the Wallet of Satoshi app.

--- a/src/routes/pages/es/zaps.md
+++ b/src/routes/pages/es/zaps.md
@@ -46,4 +46,4 @@ Por ejemplo, imagina lo siguiente:
 
 1. Tienes una dirección lightning [Stacker News](https://stacker.news/) configurada en tu perfil de Nostr, aquí es donde recibirás cualquier sats zapeado.
 1. En su navegador web, usa a Iris como su cliente y paga Zaps usando su billetera Alby a través de su extensión de Chrome
-1. En el móvil, usas a Damus como tu cliente y pagas Zaps usando la aplicación Wallet of Statoshi.
+1. En el móvil, usas a Damus como tu cliente y pagas Zaps usando la aplicación Wallet of Satoshi.

--- a/src/routes/pages/fr/zaps.md
+++ b/src/routes/pages/fr/zaps.md
@@ -46,4 +46,4 @@ Imaginez, par exemple, la situation suivante :
 
 1. Vous avez une adresse [Stacker News](https://stacker.news/) lightning dans votre profil Nostr, c'est là que vous recevrez les sats zappés.
 1. Dans votre navigateur web, vous utilisez Iris comme client et payez les Zaps en utilisant votre portefeuille Alby via leur extension chrome.
-1. Sur mobile, vous utilisez Damus comme client et payez les Zaps en utilisant l'application Wallet of Statoshi.
+1. Sur mobile, vous utilisez Damus comme client et payez les Zaps en utilisant l'application Wallet of Satoshi.


### PR DESCRIPTION
Fixed typo `Wallet of Statoshi` to `Wallet of Satoshi` on the zaps pages 