### PR TITLE
add coinos as nip-05 provider

### DIFF
--- a/src/routes/pages/en/guides/get-verified.md
+++ b/src/routes/pages/en/guides/get-verified.md
@@ -36,6 +36,7 @@ At the moment, there are several providers who are helping folks get verified fo
 -   [NIP05.social](https://nip05.social)
 -   [Nostr-Check.com](https://nostr-check.com/)
 -   [Verified Nostr](https://verified-nostr.com/)
+-   [Coinos](https://coinos.io)
 
 ## [§](#paid-verification) Pay a provider for verification
 


### PR DESCRIPTION
all coinos accounts come with a lightning address username@coinos.io and can also be used for NIP-05 if they toggle it on in their profile settings