### PR TITLE
Add cosanostr.com as free NIP-05 provider

### DIFF
--- a/src/routes/pages/de/guides/get-verified.md
+++ b/src/routes/pages/de/guides/get-verified.md
@@ -36,6 +36,7 @@ Im Moment gibt es mehrere Anbieter, bei denen du dich kostenlos verifizieren las
 -   [NIP05.social](https://nip05.social)
 -   [Nostr-Check.com](https://nostr-check.com/)
 -   [Verified Nostr](https://verified-nostr.com/)
+-   [Cosa Nostr](https://cosanostr.com)
 
 ## [§](#paid-verification) Verifiziere dich bei einem Bezahl-Service
 

--- a/src/routes/pages/en/guides/get-verified.md
+++ b/src/routes/pages/en/guides/get-verified.md
@@ -36,6 +36,7 @@ At the moment, there are several providers who are helping folks get verified fo
 -   [NIP05.social](https://nip05.social)
 -   [Nostr-Check.com](https://nostr-check.com/)
 -   [Verified Nostr](https://verified-nostr.com/)
+-   [Cosa Nostr](https://cosanostr.com)
 
 ## [§](#paid-verification) Pay a provider for verification
 

--- a/src/routes/pages/es/guides/get-verified.md
+++ b/src/routes/pages/es/guides/get-verified.md
@@ -36,6 +36,7 @@ En este momento, hay varios proveedores que están ayudando a la gente a obtener
 -   [NIP05.social](https://nip05.social)
 -   [Nostr-Check.com](https://nostr-check.com/)
 -   [Verified Nostr](https://verified-nostr.com/)
+-   [Cosa Nostr](https://cosanostr.com)
 
 ## [§](#verificación-pagada) Paga a un proveedor por la verificación
 

--- a/src/routes/pages/fa/guides/get-verified.md
+++ b/src/routes/pages/fa/guides/get-verified.md
@@ -34,6 +34,7 @@ description: چگونه هویت خود را در ناستر تایید کنید
 -   [NIP05.social](https://nip05.social)
 -   [Nostr-Check.com](https://nostr-check.com/)
 -   [Verified Nostr](https://verified-nostr.com/)
+-   [Cosa Nostr](https://cosanostr.com)
 
 ## [§](#تایید-پولی) برای تایید به یک تامین کننده پول بپردازید
 

--- a/src/routes/pages/fr/guides/get-verified.md
+++ b/src/routes/pages/fr/guides/get-verified.md
@@ -34,6 +34,7 @@ Actuellement, plusieurs fournisseurs aident les gens à se faire vérifier gratu
 -   [NIP05.social](https://nip05.social)
 -   [Nostr-Check.com](https://nostr-check.com/)
 -   [Verified Nostr](https://verified-nostr.com/)
+-   [Cosa Nostr](https://cosanostr.com)
 
 ## [§](#paid-verification) Payer un fournisseur pour la vérification
 

--- a/src/routes/pages/it/guides/get-verified.md
+++ b/src/routes/pages/it/guides/get-verified.md
@@ -36,6 +36,7 @@ Al momento, ci sono diversi fornitori che stanno aiutando le persone a ottenere 
 -   [NIP05.social](https://nip05.social)
 -   [Nostr-Check.com](https://nostr-check.com/)
 -   [Verified Nostr](https://verified-nostr.com/)
+-   [Cosa Nostr](https://cosanostr.com)
 
 ## [§](#verifica-a-pagamento) Pagare un fornitore
 

--- a/src/routes/pages/jp/guides/get-verified.md
+++ b/src/routes/pages/jp/guides/get-verified.md
@@ -37,6 +37,7 @@ NIP-05を利用するために、Nostrユーザーは自分のプロフィール
 - [NIP05.social](https://nip05.social)
 - [Nostr-Check.com](https://nostr-check.com/)
 - [Verified Nostr](https://verified-nostr.com/)
+- [Cosa Nostr](https://cosanostr.com)
 
 ## [§](#paid-verification) 有料サービスで認証する
 

--- a/src/routes/pages/nl/guides/get-verified.md
+++ b/src/routes/pages/nl/guides/get-verified.md
@@ -36,6 +36,7 @@ Op dit moment zijn er verschillende providers die mensen helpen om gratis geveri
 -   [NIP05.social](https://nip05.social)
 -   [Nostr-Check.com](https://nostr-check.com/)
 -   [Verified Nostr](https://verified-nostr.com/)
+-   [Cosa Nostr](https://cosanostr.com)
 
 ## [§](#paid-verification) Een provider betalen voor verificatie
 

--- a/src/routes/pages/pt/guides/get-verified.md
+++ b/src/routes/pages/pt/guides/get-verified.md
@@ -36,6 +36,7 @@ Neste momento existem vários prestadores que estão a ajudar as pessoas a obter
 -   [NIP05.social](https://nip05.social)
 -   [Nostr-Check.com](https://nostr-check.com/)
 -   [Verified Nostr](https://verified-nostr.com/)
+-   [Cosa Nostr](https://cosanostr.com)
 
 ## [§](#verificação-paga) Pagar a um fornecedor pela verificação
 

--- a/src/routes/pages/uk/guides/get-verified.md
+++ b/src/routes/pages/uk/guides/get-verified.md
@@ -36,6 +36,7 @@ NIP-05 дозволяє користувачеві Nostr зіставити св
 -   [NIP05.social](https://nip05.social)
 -   [Nostr-Check.com](https://nostr-check.com/)
 -   [Verified Nostr](https://verified-nostr.com/)
+-   [Cosa Nostr](https://cosanostr.com)
 
 ## [§](#paid-verification) Оплатіть верифікацію у постачальника
 

--- a/src/routes/pages/zh/guides/get-verified.md
+++ b/src/routes/pages/zh/guides/get-verified.md
@@ -36,6 +36,7 @@ NIP-05 使 Nostr 用户能够将其公钥映射到基于 DNS 的互联网标识�
 -   [NIP05.social](https://nip05.social)
 -   [Nostr-Check.com](https://nostr-check.com/)
 -   [Verified Nostr](https://verified-nostr.com/)
+-   [Cosa Nostr](https://cosanostr.com)
 
 ## [§](#paid-verification) 向提供商支付验证费用
 


### PR DESCRIPTION
This PR adds a new and free NIP-05 provider to the get-verified docs across 11 languages. Users can choose a username on cosanostr.com and use that as their NIP-05 identifier.