### PR TITLE
Added Nostrly to list of NIP-05 providers

### DIFF
--- a/src/routes/pages/de/guides/get-verified.md
+++ b/src/routes/pages/de/guides/get-verified.md
@@ -42,6 +42,7 @@ Im Moment gibt es mehrere Anbieter, bei denen du dich kostenlos verifizieren las
 
 Wenn du keine eigene Domain hast oder selbst nicht einrichten willst, kannst du auch einen kostenpflichtigen NIP-05-Service in Anspruch nehmen. In der Regel jostet das nur ein paar [Sats](https://coinmarketcap.com/alexandria/glossary/satoshi-sats). Hier sind ein paar Beispiele:
 
+-   [Nostrly](https://www.nostrly.com)
 -   [Nostrplebs](https://nostrplebs.com)
 -   [Nostr Verified](https://nostrverified.com)
 -   [Alby](https://getalby.com)

--- a/src/routes/pages/en/guides/get-verified.md
+++ b/src/routes/pages/en/guides/get-verified.md
@@ -42,6 +42,7 @@ At the moment, there are several providers who are helping folks get verified fo
 
 If you don't have your own domain or don't want to set it up yourself, you can take advantage of a free or paid (usually just a few [sats](https://coinmarketcap.com/alexandria/glossary/satoshi-sats)) NIP-05 service. Here are a few:
 
+-   [Nostrly](https://www.nostrly.com)
 -   [Nostrplebs](https://nostrplebs.com)
 -   [Nostr Verified](https://nostrverified.com)
 -   [Alby](https://getalby.com)

--- a/src/routes/pages/es/guides/get-verified.md
+++ b/src/routes/pages/es/guides/get-verified.md
@@ -42,6 +42,7 @@ En este momento, hay varios proveedores que están ayudando a la gente a obtener
 
 Si no tiene su propio dominio o no desea configurarlo usted mismo, puede aprovechar una versión gratuita o paga (generalmente solo unos pocos [sats](https://coinmarketcap.com/alexandria/glossary/satoshi-sats)) Servicio NIP-05. Aquí hay algunos:
 
+-   [Nostrly](https://www.nostrly.com)
 -   [Nostrplebs](https://nostrplebs.com)
 -   [Nostr Verified](https://nostrverified.com)
 -   [Alby](https://getalby.com)

--- a/src/routes/pages/fa/guides/get-verified.md
+++ b/src/routes/pages/fa/guides/get-verified.md
@@ -40,6 +40,7 @@ description: چگونه هویت خود را در ناستر تایید کنید
 
 اگر دامنه خود را ندارید یا نمی خواهید خودتان راه بیاندازید، می توانید از یک تامین کننده خدمات NIP-05 پولی (معمولا فقط با اندکی [ساتوشی](https://coinmarketcap.com/alexandria/glossary/satoshi-sats)) یا رایگان استفاده کنید. در اینجا چند خدمات پولی را ببینید:
 
+-   [Nostrly](https://www.nostrly.com)
 -   [Nostrplebs](https://nostrplebs.com)
 -   [Nostr Verified](https://nostrverified.com)
 -   [Alby](https://getalby.com)

--- a/src/routes/pages/fr/guides/get-verified.md
+++ b/src/routes/pages/fr/guides/get-verified.md
@@ -40,6 +40,7 @@ Actuellement, plusieurs fournisseurs aident les gens à se faire vérifier gratu
 
 Si vous n'avez pas votre propre domaine ou si vous ne voulez pas le configurer vous-même, vous pouvez profiter d'un service NIP-05 gratuit ou payant (généralement quelques [sats](https://coinmarketcap.com/alexandria/glossary/satoshi-sats)). En voici quelques-uns :
 
+-   [Nostrly](https://www.nostrly.com)
 -   [Nostrplebs](https://nostrplebs.com)
 -   [Nostr Verified](https://nostrverified.com)
 -   [Alby](https://getalby.com)

--- a/src/routes/pages/it/guides/get-verified.md
+++ b/src/routes/pages/it/guides/get-verified.md
@@ -42,6 +42,7 @@ Al momento, ci sono diversi fornitori che stanno aiutando le persone a ottenere 
 
 Se non hai un tuo dominio o non vuoi configurarlo da solo, puoi usufruire di un servizio NIP-05 gratuito o a pagamento (solitamente solo pochi [sats](https://coinmarketcap.com/alexandria/glossary/satoshi-sats)). Ecco alcuni:
 
+-   [Nostrly](https://www.nostrly.com)
 -   [Nostrplebs](https://nostrplebs.com)
 -   [Nostr Verified](https://nostrverified.com)
 -   [Alby](https://getalby.com)

--- a/src/routes/pages/jp/guides/get-verified.md
+++ b/src/routes/pages/jp/guides/get-verified.md
@@ -43,6 +43,7 @@ NIP-05を利用するために、Nostrユーザーは自分のプロフィール
 
 独自ドメインを持っていなかったり、自分で設定したくない場合は、無料または有料（通常は数[サトシ](https://coinmarketcap.com/alexandria/glossary/satoshi-sats)）のNIP-05サービスを利用することができます。いくつか紹介してみます：
 
+- [Nostrly](https://www.nostrly.com)
 - [Nostrplebs](https://nostrplebs.com)
 - [Nostr Verified](https://nostrverified.com)
 - [Alby](https://getalby.com)

--- a/src/routes/pages/nl/guides/get-verified.md
+++ b/src/routes/pages/nl/guides/get-verified.md
@@ -42,6 +42,7 @@ Op dit moment zijn er verschillende providers die mensen helpen om gratis geveri
 
 Als je geen eigen domein hebt of het niet zelf wilt instellen, kun je gebruikmaken van een gratis of betaalde  NIP-05-service. Hier zijn er een paar:
 
+-   [Nostrly](https://www.nostrly.com)
 -   [Nostrplebs](https://nostrplebs.com)
 -   [Nostr Verified](https://nostrverified.com)
 -   [Alby](https://getalby.com)

--- a/src/routes/pages/pt/guides/get-verified.md
+++ b/src/routes/pages/pt/guides/get-verified.md
@@ -42,6 +42,7 @@ Neste momento existem vários prestadores que estão a ajudar as pessoas a obter
 
 Se não tens o teu próprio domínio ou não queres configurá-lo sozinho, podes aproveitar um serviço NIP-05 gratuito ou pago (normalmente apenas alguns [sats](https://coinmarketcap.com/alexandria/glossary/satoshi-sats)). Aqui estão alguns:
 
+-   [Nostrly](https://www.nostrly.com)
 -   [Nostrplebs](https://nostrplebs.com)
 -   [Nostr Verified](https://nostrverified.com)
 -   [Alby](https://getalby.com)

--- a/src/routes/pages/uk/guides/get-verified.md
+++ b/src/routes/pages/uk/guides/get-verified.md
@@ -42,6 +42,7 @@ NIP-05 дозволяє користувачеві Nostr зіставити св
 
 Якщо у вас немає власного домену або ви не хочете налаштовувати його самостійно, ви можете скористатися безкоштовною або платною (зазвичай лише кілька [sats](https://coinmarketcap.com/alexandria/glossary/satoshi-sats)) послугою NIP-05. Ось декілька з них:
 
+-   [Nostrly](https://www.nostrly.com)
 -   [Nostrplebs](https://nostrplebs.com)
 -   [Nostr Verified](https://nostrverified.com)
 -   [Alby](https://getalby.com)

--- a/src/routes/pages/zh/guides/get-verified.md
+++ b/src/routes/pages/zh/guides/get-verified.md
@@ -42,6 +42,7 @@ NIP-05 使 Nostr 用户能够将其公钥映射到基于 DNS 的互联网标识�
 
 如果您没有自己的域名或不想自己设置它，则可以利用免费或付费（通常只需几个[聪](https://coinmarketcap.com/alexandria/glossary/satoshi-sats)）的 NIP-05 服务。以下是一些付费提供商：
 
+-   [Nostrly](https://www.nostrly.com)
 -   [Nostrplebs](https://nostrplebs.com)
 -   [Nostr Verified](https://nostrverified.com)
 -   [Alby](https://getalby.com)


### PR DESCRIPTION
Background: Nostrly is a NIP-05 provider with lightning redirect (with fallback to npub.cash). The site also includes web zap and other Nostr tools like key converter, NIP-19 inspector. The site uses NIP-98 authentication to integrate into a WordPress backend for account management.