### PR TITLE
change the locals redirect to what-is-nostr

### DIFF
--- a/src/lib/data/redirects.ts
+++ b/src/lib/data/redirects.ts
@@ -4,7 +4,7 @@ const contributionUrl = "https://github.com/nostr-how/nostr-how";
 
 const localeRedirects = supportedLocales.map((locale) => ({
     old: `/${locale}`,
-    new: `/${locale}/get-started`,
+    new: `/${locale}/what-is-nostr`,
 }));
 
 const localizedGetVerifiedRedirects = supportedLocales.map((locale) => ({


### PR DESCRIPTION
Currently, locale paths like `/en` redirect to `/en/get-started`, while the root path `/` redirects to `/en/what-is-nostr`. This change unifies the behavior by making all locale paths, including `/en`, redirect to `/en/what-is-nostr`.